### PR TITLE
Use SpringResourceAccessor instead of ClassLoaderResourceAccessor

### DIFF
--- a/liquibase-r2dbc-spring-boot-starter/src/main/kotlin/io/github/daggerok/liquibase/r2dbc/LiquibaseR2dbcAutoConfiguration.kt
+++ b/liquibase-r2dbc-spring-boot-starter/src/main/kotlin/io/github/daggerok/liquibase/r2dbc/LiquibaseR2dbcAutoConfiguration.kt
@@ -7,7 +7,7 @@ import liquibase.Liquibase
 import liquibase.database.Database
 import liquibase.database.DatabaseFactory
 import liquibase.database.jvm.JdbcConnection
-import liquibase.resource.ClassLoaderResourceAccessor
+import liquibase.integration.spring.SpringResourceAccessor
 import org.apache.logging.log4j.kotlin.logger
 import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
@@ -38,8 +38,8 @@ class LiquibaseR2dbcAutoConfiguration(private val props: LiquibaseR2dbcPropertie
 
     @Bean
     @ConditionalOnMissingBean
-    fun liquibaseR2dbcResourceAccessor(resourceLoader: ResourceLoader): ClassLoaderResourceAccessor =
-        ClassLoaderResourceAccessor(resourceLoader.classLoader)
+    fun liquibaseR2dbcResourceAccessor(resourceLoader: ResourceLoader): SpringResourceAccessor =
+        SpringResourceAccessor(resourceLoader)
             .also { log.debug { "liquibaseR2dbcResourceAccessor bean refers to: $it" } }
 
     @Bean
@@ -102,7 +102,7 @@ class LiquibaseR2dbcAutoConfiguration(private val props: LiquibaseR2dbcPropertie
 
     @Bean
     @ConditionalOnMissingBean
-    fun liquibaseR2dbcUpdate(liquibaseR2dbcResourceAccessor: ClassLoaderResourceAccessor, liquibaseR2dbcDatabase: Database) =
+    fun liquibaseR2dbcUpdate(liquibaseR2dbcResourceAccessor: SpringResourceAccessor, liquibaseR2dbcDatabase: Database) =
         ApplicationRunner {
             Liquibase(props.changeLog, liquibaseR2dbcResourceAccessor, liquibaseR2dbcDatabase)
                 .also { log.debug { "liquibaseR2dbcUpdate bean refers to: $it" } }


### PR DESCRIPTION
When running a JAR produced by the Spring Boot Gradle Plugin. The JAR that is produced will not run correctly due to the autoconfiguration using the ClassLoaderResourceAccessor. In the [Spring Boot JDBC](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java) version of the autoconfiguration SpringResourceAccessor is used, which is aware of the structure of the Spring Boot produced JAR so is able to find the liquibase changelogs.